### PR TITLE
Adding error handling for going with no items

### DIFF
--- a/src/looper.js
+++ b/src/looper.js
@@ -207,10 +207,13 @@
             // return if busy
             if (this.looping) return this;
 
-                // all items
-            var $items = this.$element.find('.item'),
+            // all items
+            var $items = this.$element.find('.item');
+            // return if no items found
+            if ($items.length == 0) return this;
+
                 // active item
-                $active = $items.filter('.active'),
+            var $active = $items.filter('.active'),
                 // active position
                 activePos = $items.index($active),
                 // next item to show


### PR DESCRIPTION
I found an error is shown in console when I used looper with no items. And I fixed it.

> TypeError: $next[0] is undefined, Line 297

You might reproduce it with below code. I confirmed with Firefox 20

``` html
<div class="looper slide" data-looper="go">
</div>
```
